### PR TITLE
Fix corruption with `lein garden auto`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ something-else some-child.including {
 }
 ```
 
+### Changes
+
+- 0.1.1 - Fixed an issue where saving certain files while running `lein garden auto` corrupted subsequent compilations.
+
 ### License
 
 Copyright (c) 2015, ReUp Distribution Inc

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject espalier "0.1.0-SNAPSHOT"
+(defproject espalier "0.1.1"
   :license {:name "BSD 2-clause \"Simplified\" License"
             :url "http://opensource.org/licenses/BSD-2-Clause"
             :year 2015

--- a/test/espalier/core_test.clj
+++ b/test/espalier/core_test.clj
@@ -35,7 +35,19 @@
   {:color :red}
   [:.warning {:color :yellow}])
 
+(defn reset-placeholder! [sym]
+  (if-let [placeholder @(resolve sym)]
+    (doseq [field [:media-queries :selectors]
+            :let [field-atom (field placeholder)]]
+      (swap! field-atom empty))
+    (swap! placeholders disj sym)))
+
+(defn reset-placeholders! []
+  (doall (map reset-placeholder! @placeholders)))
+
 (describe "Placeholder style rules"
+  (before (reset-placeholders!))
+
   (it "includes supplied rules for each selector referencing the placeholder"
     (let [styles (list
                    bold


### PR DESCRIPTION
Replaces #2: This time it also allows overwriting existing placeholders.
